### PR TITLE
- `BaseFloat` is `ApproxEquatable`.

### DIFF
--- a/Sources/ApproxEq.swift
+++ b/Sources/ApproxEq.swift
@@ -9,8 +9,8 @@
 /// Approximate equatable.
 public protocol ApproxEquatable {
 
-    /// The underlying float point number type.
-    associatedtype NumberType: BaseFloat
+    /// The underlying float pointing number type.
+    associatedtype NumberType: FloatingPoint
 
     /// Approximate comparison.
     ///
@@ -31,34 +31,6 @@ infix operator ~== : ComparisonPrecedence
 extension ApproxEquatable {
 
     public static func ~== (lhs: Self, rhs: Self) -> Bool {
-        return lhs.isClose(to: rhs, tolerance: Self.NumberType.epsilon)
-    }
-}
-
-extension Float: ApproxEquatable {
-
-    public typealias NumberType = Float
-
-    public func isClose(to other: Float, tolerance: Float = .epsilon) -> Bool {
-        if other.isZero {
-            return abs(self) <= tolerance
-        }
-        let diff = abs(self - other)
-        let m = max(abs(self), abs(other))
-        return diff <= m * tolerance
-    }
-}
-
-extension Double: ApproxEquatable {
-
-    public typealias NumberType = Double
-
-    public func isClose(to other: Double, tolerance: Double = .epsilon) -> Bool {
-        if other.isZero {
-            return abs(self) <= tolerance
-        }
-        let diff = abs(self - other)
-        let m = max(abs(self), abs(other))
-        return diff <= m * tolerance
+        return lhs.isClose(to: rhs, tolerance: Self.NumberType(1).ulp)
     }
 }

--- a/Sources/Common.swift
+++ b/Sources/Common.swift
@@ -92,14 +92,14 @@ public func mod<T: FloatVector>(_ x: T, _ y: T.Component) -> T {
 /// In GLSL, the integer part is returned via a output parameter `i`.
 /// In _Swift_ we can return both parts using a tuple *(interger part,
 /// fractional part)*.
-public func modf<T: FloatVector>(_ x: T) -> (T, T) where T.Component == Float {
+public func modf<T: FloatVector>(_ x: T) -> (i: T, T) where T.Component == Float {
     return x.split { Darwin.modf($0) }
 }
 
 /// Returns the fractional and integer parts of `x`.
 ///
 /// Both parts will have the same sign as `x`.
-public func modf<T: FloatVector>(_ x: T) -> (T, T) where T.Component == Double {
+public func modf<T: FloatVector>(_ x: T) -> (i: T, T) where T.Component == Double {
     return x.split { Darwin.modf($0) }
 }
 
@@ -157,7 +157,8 @@ public func mix<T: BaseFloat>(_ x: T, _ y: T, _ a: Bool) -> T {
 public func mix
 <
     T: FloatVector,
-    B: Vector>(_ x: T, _ y: T, _ a: B) -> T
+    B: Vector
+>(_ x: T, _ y: T, _ a: B) -> T
     where
     B.Dim == T.Dim,
     B.Component == Bool

--- a/Sources/Float.swift
+++ b/Sources/Float.swift
@@ -13,7 +13,7 @@ import simd
 //       interface generic.
 
 /// Generic float number type.
-public protocol GenericFloat: GenericSignedNumber {
+public protocol GenericFloat: GenericSignedNumber, ApproxEquatable {
 
     var fract: Self { get }
     var recip: Self { get }
@@ -25,9 +25,22 @@ public protocol GenericFloat: GenericSignedNumber {
 /// Primitive float number type.
 public protocol BaseFloat: BaseNumber, GenericFloat, FloatingPoint, ExpressibleByFloatLiteral {
 
-    static var epsilon: Self { get }
     var frexp: (Self, Int) { get }
     func ldexp(_ exp: Int) -> Self
+}
+
+extension BaseFloat {
+
+    public typealias NumberType = Self
+
+    public func isClose(to other: Self, tolerance: Self = Self.epsilon) -> Bool {
+        if other.isZero {
+            return abs(self) <= tolerance
+        }
+        let diff = abs(self - other)
+        let m = max(abs(self), abs(other))
+        return diff <= m * tolerance
+    }
 }
 
 extension Float: BaseFloat {
@@ -59,7 +72,7 @@ extension Double: BaseFloat {
 }
 
 /// Float number vector.
-public protocol FloatVector: NumberVector, GenericFloat, ApproxEquatable {
+public protocol FloatVector: NumberVector, GenericFloat {
 
     associatedtype Component: BaseFloat
 
@@ -79,7 +92,7 @@ extension FloatVector {
     }
 }
 
-extension FloatVector where Component: ApproxEquatable, Component.NumberType == Component {
+extension FloatVector where Component.NumberType == Component {
 
     public typealias NumberType = Component
 


### PR DESCRIPTION
- Add label to the return value of `modf`.
